### PR TITLE
Add initial personal website with project portfolio and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # chrge.github.io
-This is a webpage
+
+Personal website for showcasing software projects in edge devices and machine learning integration.
+
+## Development
+
+Open `index.html` in your browser to view the site locally.
+
+## Deployment
+
+Push changes to the `main` branch to update the GitHub Pages site.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chrge - Edge & ML Integration</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <h1>Chrge</h1>
+      <p>Edge Device Engineer & ML Integration Specialist</p>
+      <a href="#contact" class="btn">Get in touch</a>
+    </header>
+
+    <main>
+      <section id="about">
+        <h2>About Me</h2>
+        <p>
+          I build software solutions for edge devices, NVIDIA Jetson platforms,
+          and integrate machine learning with PLC systems.
+        </p>
+      </section>
+
+      <section id="projects">
+        <h2>Projects</h2>
+        <ul class="project-list">
+          <li>
+            <h3>Jetson Vision Inspector</h3>
+            <p>
+              Real-time defect detection on the factory floor using a Jetson
+              Xavier and custom CNN models.
+            </p>
+          </li>
+          <li>
+            <h3>Edge Analytics Gateway</h3>
+            <p>
+              Docker-based analytics stack that bridges PLC data to the cloud
+              with minimal latency.
+            </p>
+          </li>
+          <li>
+            <h3>ML-Driven PLC Tuner</h3>
+            <p>
+              Python tools that optimize PID loops with reinforcement learning.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section id="contact">
+        <h2>Contact</h2>
+        <p>Email: <a href="mailto:you@example.com">you@example.com</a></p>
+        <p>GitHub: <a href="https://github.com/chrge">github.com/chrge</a></p>
+      </section>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Chrge. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,50 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+.hero {
+  background: #1e1e1e;
+  color: #fff;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.hero .btn {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #2d8cff;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+main {
+  padding: 2rem 1rem;
+  max-width: 900px;
+  margin: auto;
+}
+
+h2 {
+  border-bottom: 2px solid #2d8cff;
+  padding-bottom: 0.3rem;
+}
+
+.project-list {
+  list-style: none;
+  padding: 0;
+}
+
+.project-list li {
+  margin-bottom: 1.5rem;
+}
+
+footer {
+  background: #f0f0f0;
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- scaffold personal portfolio site highlighting edge device and ML integration work
- add simple CSS for layout and hero styling
- document development and deployment instructions

## Testing
- `npx -y prettier README.md index.html styles.css --check`


------
https://chatgpt.com/codex/tasks/task_e_68a1c554b69c833291eb0459a0621d2b